### PR TITLE
Refactor TimePick into a class with event methods

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -58,19 +58,40 @@
                 logContainer.scrollTop = logContainer.scrollHeight;
             }
 
-            var timepickerOne = new TimePick('#one').onChange((data) => {
+            var timepickerOne = new TimePick('#one');
+            timepickerOne.on('change', (data) => {
                 log('SinglePicker ONE data', data);
                 log('SinglePicker ONE vars', timepickerOne.getValue());
             });
+            timepickerOne.on('dismiss', (data) => {
+                log('SinglePicker ONE dismiss', data);
+            });
+            timepickerOne.on('show', (data) => {
+                log('SinglePicker ONE show', data);
+            });
 
-            var timepickerTwo = new TimePick('#two').onChange((data) => {
+            var timepickerTwo = new TimePick('#two');
+            timepickerTwo.on('change', (data) => {
                 log('SinglePicker TWO data', data);
                 log('SinglePicker TWO vars', timepickerTwo.getValue());
             });
+            timepickerTwo.on('dismiss', (data) => {
+                log('SinglePicker TWO dismiss', data);
+            });
+            timepickerTwo.on('show', (data) => {
+                log('SinglePicker TWO show', data);
+            });
 
-            var timepickerThree = new TimePick('#three').onChange((data) => {
+            var timepickerThree = new TimePick('#three');
+            timepickerThree.on('change', (data) => {
                 log('SinglePicker THREE data', data);
                 log('SinglePicker THREE vars', timepickerThree.getValue());
+            });
+            timepickerThree.on('dismiss', (data) => {
+                log('SinglePicker THREE dismiss', data);
+            });
+            timepickerThree.on('show', (data) => {
+                log('SinglePicker THREE show', data);
             });
 
             const multiPicker = new TimePick('.timePicker');
@@ -80,8 +101,14 @@
                 log(`MultiPicker ${id}`, instance.getValue());
             });
 
-            multiPicker.onChange((instance) => {
+            multiPicker.on('change', (instance) => {
                 log('MultiPicker data', instance);
+            });
+            multiPicker.on('dismiss', (instance) => {
+                log('MultiPicker dismiss', instance);
+            });
+            multiPicker.on('show', (instance) => {
+                log('MultiPicker show', instance);
             });
 
             log('MultiPicker: getValue("testing")', multiPicker.getValue('testing'));

--- a/time-pick.js
+++ b/time-pick.js
@@ -49,42 +49,36 @@
  * @method setValid(isValid) - Set validity state
  */
 class TimePick {
-
     static DEFAULT_OPTIONS = {
         step: 30,
         placeholder: '00:00',
     };
+
+    static instances = new Map();
 
     constructor(selector, options) {
         const { type, value } = this.isInstanceInput(selector);
 
         if (type === 'class') {
             const elements = document.querySelectorAll(`.${value}`);
-            const instances = new Map();
-
             elements.forEach((el, index) => {
-                if (!el.id) el.id = `timePicker_${index}`;
-                instances.set(el.id, new TimePick(`#${el.id}`, options));
+                if (!el.id) el.id = `timePicker_${this.randomString(5)}`;
+                TimePick.instances.set(el.id, new TimePick(`#${el.id}`, options));
             });
 
             return {
-                instances,
+                instances: TimePick.instances,
                 on: (event, callback) => {
-                    instances.forEach(instance => instance.on(event, callback));
+                    TimePick.instances.forEach(instance => instance.on(event, callback));
                 },
-                getAll: () => instances,
-                getValue: (id) => instances.get(id)?.getValue(),
-                setValue: (id, totalMinutes) => instances.get(id)?.setValue(totalMinutes),
-                setValid: (id, isValid) => instances.get(id)?.setValid(isValid)
+                getAll: () => TimePick.instances,
+                getValue: (id) => TimePick.instances.get(id)?.getValue(),
+                setValue: (id, totalMinutes) => TimePick.instances.get(id)?.setValue(totalMinutes),
+                setValid: (id, isValid) => TimePick.instances.get(id)?.setValid(isValid)
             };
         }
 
         this.config = { ...TimePick.DEFAULT_OPTIONS, ...options };
-        this.eventHandlers = {
-            change: [],
-            dismiss: [],
-            show: []
-        };
 
         this.hour = 0;
         this.minute = 0;
@@ -92,13 +86,17 @@ class TimePick {
         this.buttonActive = false;
         this.elements = null;
         this.id = this.randomString(5);
+        this.eventHandlers = {
+            change: [],
+            dismiss: [],
+            show: []
+        };
 
         this.elements = document.querySelectorAll(selector);
 
-        // only handle the first matching element
-        this.inputElement = this.elements[0];
-        this.inputElement.setAttribute("TimePick", "input-" + this.id);
-        this.inputElement.insertAdjacentHTML("afterend", this.getButtonHTML(this.id));
+        let inputElement = this.elements[0];
+        inputElement.setAttribute("TimePick", "input-" + this.id);
+        inputElement.insertAdjacentHTML("afterend", this.getButtonHTML(this.id));
 
         let btn = document.querySelector(`[TimePick="input-${this.id}"] + .TimePick_BTN .TimePick_ICON`);
         if (btn) {
@@ -108,7 +106,7 @@ class TimePick {
                 popup.style.display = popup.style.display === "flex" ? "none" : "flex";
                 this.addOverlayListener(popup, btn);
                 this.handleTimeUpdate();
-                this.triggerEvent('show');
+                this.triggerEvent('show', this.getValue());
             };
         }
 
@@ -145,41 +143,24 @@ class TimePick {
             };
         });
 
-        // Initialize from existing value if present
-        if (this.inputElement.value) {
-            let [hour, minute] = this.inputElement.value.split(":").map(Number);
+        if (inputElement.value) {
+            let [hour, minute] = inputElement.value.split(":").map(Number);
             this.hour = hour;
             this.minute = minute;
             this.handleTimeUpdate();
         } else {
-            this.inputElement.setAttribute("value", this.config.placeholder);
+            inputElement.setAttribute("value", this.config.placeholder);
         }
     }
 
-    on(event, callback) {
-        if (this.eventHandlers[event]) {
-            this.eventHandlers[event].push(callback);
+    isInstanceInput(selector) {
+        if (typeof selector === 'string') {
+            return {
+                type: selector.startsWith('#') ? 'id' : 'class',
+                value: selector.substring(1)
+            };
         }
-    }
-
-    triggerEvent(event) {
-        if (this.eventHandlers[event]) {
-            this.eventHandlers[event].forEach(callback => callback(this));
-        }
-    }
-
-    addOverlayListener(popup, btn) {
-        if (popup.hasAttribute('overlayDissmiss')) return;
-        popup.setAttribute('overlayDissmiss', true);
-
-        document.addEventListener('click', (e) => {
-            if (!popup?.style.display === "flex") return;
-            if (popup.contains(e.target) || btn.id === e.target.id) return;
-
-            popup.style.display = "none";
-            btn.classList.remove("active");
-            this.triggerEvent('dismiss');
-        });
+        return { type: 'element', value: selector };
     }
 
     randomString(length) {
@@ -193,34 +174,38 @@ class TimePick {
     }
 
     getButtonHTML(id) {
-        const theme = (this.inputElement.classList.contains("theme-dark")) ? "theme-dark" : (this.inputElement.classList.contains("theme-light")) ? "theme-light" : "";
+        const theme = (this.elements[0].classList.contains("theme-dark")) ? "theme-dark" : (this.elements[0].classList.contains("theme-light")) ? "theme-light" : "";
 
         return `<button class="TimePick_BTN TimePick_${id} ${theme}">
         <svg class="TimePick_ICON ${theme}" id="${id}" height="20" width="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path class="timepick-icon ${theme}" d="M22 12C22 17.52 17.52 22 12 22C6.48 22 2 17.52 2 12C2 6.48 6.48 2 12 2C17.52 2 22 6.48 22 12Z"  stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path> <path class="timepick-icon ${theme}" d="M15.71 15.18L12.61 13.33C12.07 13.01 11.63 12.24 11.63 11.61V7.51001" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>
         <div class="TimePick_POPUP ${theme}" id="popup_${id}">
         <div class="hour ${theme}">
-        <div class="adjustbtn uparrow ${theme}" data='{"type": "hour", "action": "up"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
+        <div class="adjustbtn uparrow ${theme}" data='{"type": "hour", "action": "up"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
         <div id="label_hour_${id}" class="label ${theme}">00</div>
-        <div class="adjustbtn downarrow ${theme}" data='{"type": "hour", "action": "down"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30" transform="rotate(180)"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
+        <div class="adjustbtn downarrow ${theme}" data='{"type": "hour", "action": "down"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30" transform="rotate(180)"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
         </div>
         <div class="minute ${theme}">
-        <div class="adjustbtn uparrow ${theme}" data='{"type": "minute", "action": "up"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
+        <div class="adjustbtn uparrow ${theme}" data='{"type": "minute", "action": "up"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
         <div id="label_minute_${id}" class="label ${theme}">00</div>
-        <div class="adjustbtn downarrow ${theme}" data='{"type": "minute", "action": "down"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30" transform="rotate(180)"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
+        <div class="adjustbtn downarrow ${theme}" data='{"type": "minute", "action": "down"}'><svg class="svg-arrow ${theme}" height="20px" width="20px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-30.7 -30.7 573.13 573.13" xml:space="preserve"  stroke-width="30" transform="rotate(180)"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <g> <path class="timepick-icon ${theme}" d="M508.788,371.087L263.455,125.753c-4.16-4.16-10.88-4.16-15.04,0L2.975,371.087c-4.053,4.267-3.947,10.987,0.213,15.04 c4.16,3.947,10.667,3.947,14.827,0l237.867-237.76l237.76,237.76c4.267,4.053,10.987,3.947,15.04-0.213 C512.734,381.753,512.734,375.247,508.788,371.087z"></path> </g> </g> </g></svg></div>
         </div>
         <div class="ampm ${theme}"></div>
         </div>
         </button>`;
     }
 
-    isInstanceInput(selector) {
-        if (typeof selector === 'string') {
-            return {
-                type: selector.startsWith('#') ? 'id' : 'class',
-                value: selector.substring(1)
-            };
-        }
-        return { type: 'element', value: selector };
+    addOverlayListener(popup, btn) {
+        if (popup.hasAttribute('overlayDissmiss')) return;
+        popup.setAttribute('overlayDissmiss', true);
+
+        document.addEventListener('click', (e) => {
+            if (!popup?.style.display === "flex") return;
+            if (popup.contains(e.target) || btn.id === e.target.id) return;
+
+            popup.style.display = "none";
+            btn.classList.remove("active");
+            this.triggerEvent('dismiss', this.getValue());
+        });
     }
 
     handleTimeUpdate() {
@@ -229,12 +214,24 @@ class TimePick {
 
         document.getElementById('label_hour_' + this.id).innerText = hrview;
         document.getElementById('label_minute_' + this.id).innerText = mnview;
-        this.inputElement.value = hrview + ":" + mnview;
+        this.elements[0].value = hrview + ":" + mnview;
 
         this.totalMinutes = (this.hour * 60) + this.minute;
-        this.buttonActive = btn.classList.contains("active");
+        this.buttonActive = document.querySelector(`[TimePick="input-${this.id}"] + .TimePick_BTN .TimePick_ICON`).classList.contains("active");
 
-        this.triggerEvent('change');
+        this.triggerEvent('change', this.getValue());
+    }
+
+    triggerEvent(event, data) {
+        if (this.eventHandlers[event]) {
+            this.eventHandlers[event].forEach(callback => callback(data));
+        }
+    }
+
+    on(event, callback) {
+        if (this.eventHandlers[event]) {
+            this.eventHandlers[event].push(callback);
+        }
     }
 
     getValue() {
@@ -256,9 +253,9 @@ class TimePick {
     setValid(isValid) {
         let button = document.getElementById('adProgramm');
 
-        if (!this.inputElement || !button) return;
+        if (!this.elements[0] || !button) return;
 
-        this.inputElement.classList.toggle('invalid', !isValid);
+        this.elements[0].classList.toggle('invalid', !isValid);
         button.disabled = !isValid;
     }
 }


### PR DESCRIPTION
Refactor `TimePick` into a class with methods for event handling.

* **time-pick.js**
  - Convert `TimePick` function into a class named `TimePick`.
  - Add `on` method to register event handlers for "change", "dismiss", and "show" events.
  - Replace `instanceCallback` with an event handler map.
  - Update constructor to initialize event handler map and instance variables.
  - Update methods to use class properties and methods.
  - Add `triggerEvent` method to call registered event handlers.
  - Update `getValue`, `setValue`, and `setValid` methods to use class properties.

* **index.htm**
  - Update `TimePick` usage to use `on` method for "change" event.
  - Add `on` method usage for "dismiss" and "show" events.
  - Update log function to handle new event data.
  - Remove old `onChange` method usage.

